### PR TITLE
Add a control wrapper to make logging more verbose

### DIFF
--- a/src/controls.jl
+++ b/src/controls.jl
@@ -13,12 +13,12 @@ Step(; n=5) = Step(n)
              body="Train for `n` more iterations. "*
              "Will never trigger a stop. ")
 
-function update!(c::Step, model, verbosity, state=(n_iterations = 0,))
-    n_iterations = state.n_iterations
+function update!(c::Step, model, verbosity, state=(new_iterations = 0,))
+    new_iterations = state.new_iterations
     verbosity > 1 &&
         @info "Stepping model for $(c.n) more iterations. "
     train!(model, c.n)
-    state  = (n_iterations = n_iterations + c.n,)
+    state  = (new_iterations = new_iterations + c.n,)
     return state
 end
 

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -305,7 +305,7 @@ end
 done(c::WithLossDo, state) = state.done
 
 function takedown(c::WithLossDo, verbosity, state)
-    verbosity > 1 && @info "final loss: $state.loss. "
+    verbosity > 1 && @info "final loss: $(state.loss). "
     if state.done
         message = c.stop_message === nothing ?
             "Stop triggered by a `WithLossDo` control. " :

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -1,4 +1,4 @@
-# # TRAIN
+# # Step
 
 struct Step
     n::Int
@@ -22,7 +22,11 @@ function update!(c::Step, model, verbosity, state=(new_iterations = 0,))
     return state
 end
 
-takedown(c::Step, verbosity, state) = state
+@inline function takedown(c::Step, verbosity, state)
+    verbosity > 1 &&
+        @info "A total of $(state.new_iterations) iterations added. "
+    return state
+end
 
 # # Info
 
@@ -36,7 +40,7 @@ Info(; f::Function=identity) = Info(f)
 @create_docs(Info,
              header="Info(f=identity)",
              example="Info(my_loss_function)",
-             body="Log at the `Info` level the value of `f(m)`, "*
+             body="Log to `Info` the value of `f(m)`, "*
              "where `m` "*
              "is the object being iterated. If "*
              "`IterativeControl.expose(m)` has been overloaded, then "*
@@ -46,12 +50,12 @@ Info(; f::Function=identity) = Info(f)
              "See also [`Warn`](@ref), [`Error`](@ref). ")
 
 function update!(c::Info, model, verbosity, args...)
-    verbosity < 1 || @info _log_eval(c.f, model)
+    verbosity > 0 && @info _log_eval(c.f, model)
     return nothing
 end
 
 
-# # WARN
+# # Warn
 
 struct Warn{P<:Function,F<:Union{Function,String}}
     predicate::P
@@ -66,7 +70,7 @@ Warn(predicate; f="") = Warn(predicate, f)
              example="Warn(m -> length(m.cache) > 100, "*
              "f=\"Memory low\")",
              body="If `predicate(m)` is `true`, then "*
-             "log at the `Warn` level the value of `f` "*
+             "log to `Warn` the value of `f` "*
              "(or `f(IterationControl.expose(m))` if `f` is a function). "*
              "Here `m` "*
              "is the object being iterated.\n\n"*
@@ -74,27 +78,27 @@ Warn(predicate; f="") = Warn(predicate, f)
              "sufficiently low.\n\n"*
              "See also [`Info`](@ref), [`Error`](@ref). ")
 
-function update!(c::Warn, model, verbosity, args...)
-    verbosity > 1 && c.predicate(model) &&
-        @warn _log_eval(c.f, model)
-    return nothing
-end
-
-function update!(c::Warn, model, verbosity, warnings=())
+function update!(c::Warn, model, verbosity, state=(warnings=(),))
+    warnings = state.warnings
     if c.predicate(model)
         warning = _log_eval(c.f, model)
-        verbosity < 1 || @warn warning
-        state = tuple(warnings..., warning)
+        verbosity > -1 && @warn warning
+        newstate = (warnings = tuple(warnings..., warning),)
     else
-        state = warnings
+        newstate = state
     end
+    return newstate
+end
+
+function takedown(c::Warn, verbosity, state)
+    warnings = join(state.warnings, "\n")
+    verbosity > 1 && !isempty(warnings) &&
+        @warn "A `Warn` control issued these warnings:\n$warnings"
     return state
 end
 
-takedown(c::Warn, verbosity, state) = (warnings = state,)
 
-
-# # ERROR
+# # Error
 
 struct Error{P<:Function,F<:Union{Function,String}}
     predicate::P
@@ -301,6 +305,7 @@ end
 done(c::WithLossDo, state) = state.done
 
 function takedown(c::WithLossDo, verbosity, state)
+    verbosity > 1 && @info "final loss: $state.loss. "
     if state.done
         message = c.stop_message === nothing ?
             "Stop triggered by a `WithLossDo` control. " :
@@ -355,6 +360,8 @@ end
 done(c::WithTrainingLossesDo, state) = state.done
 
 function takedown(c::WithTrainingLossesDo, verbosity, state)
+    verbosity > 1 &&
+        @info "final training loss: $(state.latest_training_loss). "
     if state.done
         message = c.stop_message === nothing ?
             "Stop triggered by a `WithTrainingLossesDo` control. " :
@@ -403,6 +410,7 @@ end
 done(c::WithNumberDo, state) = state.done
 
 function takedown(c::WithNumberDo, verbosity, state)
+    verbosity > 1 && @info "final number: $(state.n). "
     if state.done
         message = c.stop_message === nothing ?
             "Stop triggered by a `WithNumberDo` control. " :

--- a/src/train.jl
+++ b/src/train.jl
@@ -20,6 +20,15 @@ function train!(model, controls...; verbosity::Int=1)
         finished = done(control, state)
     end
 
+    # reporting final loss and training loss if available:
+    loss = IterationControl.loss(model)
+    training_losses = IterationControl.training_losses(model)
+    if verbosity > 0
+        loss isa Nothing || @info "final loss: $loss"
+        training_losses isa Nothing ||
+            @info "final training loss: $(training_losses[end])"
+    end
+
     # finalization:
     return takedown(control, verbosity, state)
 end

--- a/src/wrapped_controls.jl
+++ b/src/wrapped_controls.jl
@@ -16,11 +16,11 @@ Wrap `control` to make in more (or less) verbose. The same as
 louder(c; by=1) = Louder(c, by)
 
 # api:
-done(::Louder, state) = state
+done(d::Louder, state) = done(d.control, state)
 update!(d::Louder, model, verbosity, args...) =
-    update!(d.control, model, verbosity + d.by)
-takedown(d::Louder, model, verbosity, state) =
-    takedown(d.control, model, verbosity + d.by, state)
+    update!(d.control, model, verbosity + d.by, args...)
+takedown(d::Louder, verbosity, state) =
+    takedown(d.control, verbosity + d.by, state)
 
 
 # # Debug

--- a/src/wrapped_controls.jl
+++ b/src/wrapped_controls.jl
@@ -1,3 +1,28 @@
+# # Louder
+
+struct Louder{C}
+    control::C
+    by::Int64
+end
+
+"""
+    IterationControl.louder(control, by=1)
+
+Wrap `control` to make in more (or less) verbose. The same as
+`control`, but as if the global `verbosity` were increased by the value
+`by`.
+
+"""
+louder(c; by=1) = Louder(c, by)
+
+# api:
+done(::Louder, state) = state
+update!(d::Louder, model, verbosity, args...) =
+    update!(d.control, model, verbosity + d.by)
+takedown(d::Louder, model, verbosity, state) =
+    takedown(d.control, model, verbosity + d.by, state)
+
+
 # # Debug
 
 struct Debug{C}

--- a/test/controls.jl
+++ b/test/controls.jl
@@ -11,7 +11,8 @@
     state = IC.update!(c, m, 0, state)
     @test m.training_losses == all_training_losses[3:4]
     @test !IC.done(c, state)
-    @test IC.takedown(c, 1, state) == (new_iterations = 4,)
+    @test_logs((:info, r"A total of "),
+               @test IC.takedown(c, 2, state) == (new_iterations = 4,))
 end
 
 @testset "Info" begin
@@ -32,47 +33,50 @@ end
     c = Warn(m -> m.root > 2.4)
 
     IC.train!(m, 1)
-    @test_logs (:warn, "") IC.update!(c, m, 2)
     @test_logs (:warn, "") IC.update!(c, m, 1)
-    state = @test_logs IC.update!(c, m, 0)
-    @test state === ("", )
+    @test_logs (:warn, "") IC.update!(c, m, 0)
+    state = @test_logs IC.update!(c, m, -1)
+    @test state === (warnings=("", ),)
 
     IC.train!(m, 1)
-    @test_logs  IC.update!(c, m, 2)
     @test_logs  IC.update!(c, m, 1)
-    state = @test_logs IC.update!(c, m, 0)
-    @test state === ()
+    @test_logs  IC.update!(c, m, 0)
+    state = @test_logs IC.update!(c, m, -1)
+    @test state === (warnings=(),)
 
     m = SquareRooter(4)
     IC.train!(m, 1)
     state =  IC.update!(c, m, -1)
-    @test_logs (:warn, "") IC.update!(c, m, 2, state)
     @test_logs (:warn, "") IC.update!(c, m, 1, state)
-    state = @test_logs IC.update!(c, m, 0, state)
-    @test state === ("", "")
+    @test_logs (:warn, "") IC.update!(c, m, 0, state)
+    state = @test_logs IC.update!(c, m, -1, state)
+    @test state === (warnings=("", ""),)
 
     IC.train!(m, 1)
-    @test_logs  IC.update!(c, m, 2, state)
+    @test_logs  IC.update!(c, m, 1, state)
     @test_logs  IC.update!(c, m, 0, state)
     state = @test_logs IC.update!(c, m, -, state)
-    @test state === ("", "")
+    @test state === (warnings=("", ""),)
 
     m = SquareRooter(4)
     c = Warn(m -> m.root > 2.4, f = m->m.root)
 
     IC.train!(m, 1)
-    @test_logs (:warn, 2.5) IC.update!(c, m, 2)
     @test_logs (:warn, 2.5) IC.update!(c, m, 1)
-    state = @test_logs IC.update!(c, m, 0)
-    @test state === (2.5, )
+    @test_logs (:warn, 2.5) IC.update!(c, m, 0)
+    state = @test_logs IC.update!(c, m, -1)
+    @test state === (warnings=(2.5, ),)
 
-    @test_logs (:warn, 2.5) IC.update!(c, m, 2, state)
     @test_logs (:warn, 2.5) IC.update!(c, m, 1, state)
-    state = @test_logs IC.update!(c, m, 0, state)
-    @test state === (2.5, 2.5)
+    @test_logs (:warn, 2.5) IC.update!(c, m, 0, state)
+    state = @test_logs IC.update!(c, m, -1, state)
+    @test state === (warnings=(2.5, 2.5),)
 
     @test !IC.done(c, state)
-    @test IC.takedown(c, 10, state) == (warnings = (2.5, 2.5),)
+    @test_logs((:warn, r"A `Warn`"),
+               @test IC.takedown(c, 2, state) == (warnings = (2.5, 2.5),))
+    @test_logs @test IC.takedown(c, 1, state) == (warnings = (2.5, 2.5),)
+
 end
 
 @testset "Error" begin
@@ -181,8 +185,11 @@ end
     state = IC.update!(c, m, 1, state)
     @test !state.done
     @test v ≈ [2.25, (3281/1640)^2 - 4]
-    @test IC.takedown(c, 0, state) ==
+    @test IC.takedown(c, 1, state) ==
         (loss=v[end], done = false, log="")
+    @test_logs((:info, r"final loss"),
+               @test IC.takedown(c, 2, state) ==
+               (loss=v[end], done = false, log=""))
 
     v = Float64[]
     f2(loss) = (push!(v, loss); last(v) < 0.02)
@@ -200,6 +207,17 @@ end
         (loss = v[end],
          done = true,
          log="Stop triggered by a `WithLossDo` control. ")
+    @test_logs((:info, r"Stop triggered"),
+               @test IC.takedown(c, 1, state) ==
+               (loss = v[end],
+                done = true,
+                log="Stop triggered by a `WithLossDo` control. "))
+    @test_logs((:info, r"final loss"),
+               (:info, r"Stop triggered"),
+               @test IC.takedown(c, 2, state) ==
+               (loss = v[end],
+                done = true,
+                log="Stop triggered by a `WithLossDo` control. "))
 
     v = Float64[]
     f3(loss) = (push!(v, loss); last(v) < 0.02)
@@ -236,6 +254,10 @@ end
     @test v ≈ [1.5, 0.45]
     @test IC.takedown(c, 0, state) ==
         (latest_training_loss = v[end], done = false, log="")
+    @test_logs((:info, r"final train"),
+               @test IC.takedown(c, 2, state) ==
+               (latest_training_loss=v[end], done = false, log=""))
+
 
     v = Float64[]
     f1(training_loss) = (push!(v, last(training_loss)); last(v) < 0.5)
@@ -253,6 +275,17 @@ end
         (latest_training_loss = v[end],
          done = true,
          log="Stop triggered by a `WithTrainingLossesDo` control. ")
+    @test_logs((:info, r"Stop "),
+               @test IC.takedown(c, 1, state) ==
+               (latest_training_loss = v[end],
+                done = true,
+                log="Stop triggered by a `WithTrainingLossesDo` control. "))
+    @test_logs((:info, r"final train"),
+               (:info, r"Stop"),
+               @test IC.takedown(c, 2, state) ==
+               (latest_training_loss = v[end],
+                done = true,
+                log="Stop triggered by a `WithTrainingLossesDo` control. "))
 
     v = Float64[]
     f2(training_loss) = (push!(v, last(training_loss)); last(v) < 0.5)
@@ -287,6 +320,8 @@ end
     @test !state.done
     @test v == [1, 2]
     @test IC.takedown(c, 0, state) == (done = false, n = 2, log="")
+    @test_logs((:info, r"final number"),
+               @test IC.takedown(c, 2, state) == (done = false, n = 2, log=""))
 
     v = Int[]
     f2(n) = (push!(v, n); last(n) > 1)
@@ -304,6 +339,17 @@ end
         (done = true,
          n= 2,
          log="Stop triggered by a `WithNumberDo` control. ")
+    @test_logs((:info, r"Stop"),
+               @test IC.takedown(c, 1, state) ==
+               (done = true,
+                n= 2,
+                log="Stop triggered by a `WithNumberDo` control. "))
+    @test_logs((:info, r"final number"),
+               (:info, r"Stop"),
+               @test IC.takedown(c, 2, state) ==
+               (done = true,
+                n= 2,
+                log="Stop triggered by a `WithNumberDo` control. "))
 
     v = Int[]
     f3(n) = (push!(v, n); last(n) > 1)

--- a/test/controls.jl
+++ b/test/controls.jl
@@ -6,12 +6,12 @@
     m = SquareRooter(4)
     c = Step(n=2)
     state = IC.update!(c, m, 0)
-    @test state === (n_iterations = 2,)
+    @test state === (new_iterations = 2,)
     @test m.training_losses == all_training_losses[1:2]
     state = IC.update!(c, m, 0, state)
     @test m.training_losses == all_training_losses[3:4]
     @test !IC.done(c, state)
-    @test IC.takedown(c, 1, state) == (n_iterations = 4,)
+    @test IC.takedown(c, 1, state) == (new_iterations = 4,)
 end
 
 @testset "Info" begin

--- a/test/train.jl
+++ b/test/train.jl
@@ -1,7 +1,7 @@
 @testset "basic integration" begin
     m = SquareRooter(4)
     report = IC.train!(m, Step(2),  InvalidValue(), NumberLimit(3); verbosity=0);
-    @test report[1] == (Step(2), (n_iterations = 6,))
+    @test report[1] == (Step(2), (new_iterations = 6,))
     @test report[2] == (InvalidValue(), (done=false, log=""))
     report[3] == (NumberLimit(3),
                   (done=true,

--- a/test/train.jl
+++ b/test/train.jl
@@ -1,6 +1,6 @@
 @testset "basic integration" begin
     m = SquareRooter(4)
-    report = IC.train!(m, Step(2),  InvalidValue(), NumberLimit(3); verbosity=0);
+    report = IC.train!(m, Step(2), InvalidValue(), NumberLimit(3); verbosity=0);
     @test report[1] == (Step(2), (new_iterations = 6,))
     @test report[2] == (InvalidValue(), (done=false, log=""))
     report[3] == (NumberLimit(3),
@@ -15,6 +15,7 @@
                (:info, r"Stepping model for 2 more iterations"),
                (:info, r"Stepping model for 2 more iterations"),
                (:info, r"Stepping model for 2 more iterations"),
+               (:info, r"A total of 6 iterations added"),
                (:info, r"Stop triggered by NumberLimit"),
                IC.train!(m, Step(2),
                          InvalidValue(),

--- a/test/train.jl
+++ b/test/train.jl
@@ -9,12 +9,16 @@
                    "stopping criterion. "))
 
     m = SquareRooter(4)
-    @test_logs((:info, r"Stop triggered by Num"),
+    @test_logs((:info, r"final loss"),
+               (:info, r"final training loss"),
+               (:info, r"Stop triggered by Num"),
                IC.train!(m, Step(2),  InvalidValue(), NumberLimit(3)));
     @test_logs((:info, r"Using these controls"),
                (:info, r"Stepping model for 2 more iterations"),
                (:info, r"Stepping model for 2 more iterations"),
                (:info, r"Stepping model for 2 more iterations"),
+               (:info, r"final loss"),
+               (:info, r"final training loss"),
                (:info, r"A total of 6 iterations added"),
                (:info, r"Stop triggered by NumberLimit"),
                IC.train!(m, Step(2),
@@ -55,7 +59,7 @@ end
               Step(1),
               IterationControl.skip(
                   WithNumberDo(x->push!(numbers, x)), predicate=3),
-              NumberLimit(10))
+              NumberLimit(10), verbosity=0)
     @test numbers == [1, 2, 3]
 end
 
@@ -67,4 +71,3 @@ end
 #               WithNumberDo(),
 #               IterationControl.skip(WithLossDo(), predicate=1),
 #               IterationControl.finish_loudly(WithLossDo(_->nothing)))
-

--- a/test/train.jl
+++ b/test/train.jl
@@ -63,11 +63,16 @@ end
     @test numbers == [1, 2, 3]
 end
 
-# @test "finish loudly" begin
-#     model = IterationControl.SquareRooter(4)
-#     IC.train!(model,
-#               Step(1),
-#               Threshold(2.1),
-#               WithNumberDo(),
-#               IterationControl.skip(WithLossDo(), predicate=1),
-#               IterationControl.finish_loudly(WithLossDo(_->nothing)))
+@testset "integration test related to #38" begin
+    model = IterationControl.SquareRooter(4)
+    @test_logs((:info, r"number"),
+               (:info, r"number"),
+               (:info, r"final loss"),
+               (:info, r"final training loss"),
+               (:info, r"Stop triggered by"),
+               IC.train!(model,
+                         Step(1),
+                         Threshold(2.1),
+                         WithNumberDo(),
+                         IterationControl.skip(WithLossDo(), predicate=3)))
+end

--- a/test/train.jl
+++ b/test/train.jl
@@ -58,3 +58,13 @@ end
               NumberLimit(10))
     @test numbers == [1, 2, 3]
 end
+
+# @test "finish loudly" begin
+#     model = IterationControl.SquareRooter(4)
+#     IC.train!(model,
+#               Step(1),
+#               Threshold(2.1),
+#               WithNumberDo(),
+#               IterationControl.skip(WithLossDo(), predicate=1),
+#               IterationControl.finish_loudly(WithLossDo(_->nothing)))
+

--- a/test/wrapped_controls.jl
+++ b/test/wrapped_controls.jl
@@ -1,3 +1,24 @@
+@testset "louder" begin
+    m = SquareRooter(4)
+    control = Warn(_->true, f="42")
+
+    c = IC.louder(control, by=0)
+    IC.train!(m, 1)
+    state = @test_logs IC.update!(c, m, -1)
+    IC.train!(m, 2)
+    state = @test_logs (:warn, r"42") IC.update!(c, m, 0, state)
+    @test_logs IC.takedown(c, 1, state)
+    @test_logs (:warn, r"A ") IC.takedown(c, 2, state)
+
+    c = IC.louder(control, by=1)
+    IC.train!(m, 1)
+    state = @test_logs IC.update!(c, m, -2)
+    IC.train!(m, 2)
+    state = @test_logs (:warn, r"42") IC.update!(c, m, -1, state)
+    @test_logs IC.takedown(c, 0, state)
+    @test_logs (:warn, r"A ") IC.takedown(c, 1, state)
+end
+
 @testset "debug" begin
     m = SquareRooter(4)
     test_controls = [Step(2), InvalidValue(), GL(), Callback(println)]


### PR DESCRIPTION
Also, arrange for the final loss and training loss, when available, to be logged to `Info` at the default verbosity=1.