### PR TITLE
Add `needs_loss` and `needs_training_losses` control traits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IterationControl"
 uuid = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 EarlyStopping = "792122b4-ca99-40de-a6bc-6742525f08b6"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ EarlyStopping = "792122b4-ca99-40de-a6bc-6742525f08b6"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [compat]
-EarlyStopping = "0.2"
+EarlyStopping = "0.3"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ true` to take value true. Otherwise `control` is applied anyway, and
 A second trait `needs_training_losses(control)` serves an analogous
 purpose for training losses.
 
-Here's how `IterationControl.train!` calls these methods:
+Here's a simplified version of how `IterationControl.train!` calls
+these methods:
 
 ```julia
 function train!(model, controls...; verbosity::Int=1)
@@ -265,6 +266,14 @@ function train!(model, controls...; verbosity::Int=1)
 	n = 1 # counts control cycles
 	state = update!(control, model, verbosity, n)
 	finished = done(control, state)
+	
+    # checks that model supports control:
+    if needs_loss(control) && loss(model) === nothing
+        throw(ERR_NEEDS_LOSS)
+    end
+    if needs_training_losses(control) && training_losses(model) === nothing
+        throw(ERR_NEEDS_TRAINING_LOSSES)
+    end
 
 	# subsequent training events:
 	while !finished

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------
-# # MACHINE METHODS
+# # MODEL METHODS
 
 # *models* are externally defined objects with certain functionality
 # that is exposed by overloading these methods:
@@ -21,7 +21,7 @@ err_ingest(model) =
 train!(model, Δn) = throw(err_train(model))
 
 
-# ## REQUIRED FOR SOME CONTROL
+# ## REQUIRED FOR SOME CONTROLS
 
 # extract a single numerical estimate of `models`'s performance such
 # as an out-of-sample loss; smaller is understood to be better:
@@ -51,7 +51,7 @@ expose(model, ::Val{false}) = expose(model)
 # # CONTROL METHODS
 
 # compulsory: `update!`
-# optional: `done`, `takedown`
+# optional: `done`, `takedown`, `needs_training_losses`
 
 # called after first training event; returns initialized control
 # "state":
@@ -63,10 +63,23 @@ update!(control, model, verbosity, n, state) = state
 # should we stop?
 done(control, state) = false
 
-# What to do after this control, or some other control, has triggered
+# What to do after `control`, or some other control, has triggered
 # a stop. Returns user-inspectable outcomes associated with the
 # control's applications (separate from logging). This should be a
 # named tuple, except for composite controls which return a tuple of
 # named tuples (see composite_controls.jl):
 takedown(control, verbosity, state) = NamedTuple()
 
+# If it is nonsensical to apply `control` to any model for which
+# `training_losses(model)` has not been overloaded and we want an
+# error thrown when this is attempted, then overload this trait to
+# take the value `true`. Otherwise `control` is applied anyway, and
+# `training_losses`, if called, returns `nothing`.
+needs_training_losses(control) = false
+
+# If it is nonsensical to apply `control` to any model for which
+# `loss(model)` has not been overloaded and we want an error thrown
+# when this is attempted, then overload this trait to take the value
+# `true`. Otherwise `control` is applied anyway, and
+# `loss`, if called, returns `nothing`.
+needs_loss(control) = false

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -291,7 +291,7 @@ WithLossDo(; f=x->@info("loss: $x"), kwargs...) = WithLossDo(f, kwargs...)
              "if the value returned by `f` is `true`, logging the "*
              "`stop_message` if specified. ")
 
-EarlyStopping.needs_loss(::Type{<:WithLossDo}) = true
+needs_loss(::WithLossDo) = true
 
 function update!(c::WithLossDo,
                  model,
@@ -347,7 +347,7 @@ WithTrainingLossesDo(; f=v->@info("training: $v"), kwargs...) =
              "if the value returned by `f` is `true`, logging the "*
              "`stop_message` if specified. ")
 
-EarlyStopping.needs_training_losses(::Type{<:WithTrainingLossesDo}) = true
+needs_training_losses(::WithTrainingLossesDo) = true
 
 function update!(c::WithTrainingLossesDo,
                  model,

--- a/src/train.jl
+++ b/src/train.jl
@@ -1,11 +1,18 @@
 const ERR_TRAIN = ArgumentError("`IterationControl.train!` needs at "*
-    "least two arguments. ")
+                                "least two arguments. ")
+
+const ERR_NEEDS_LOSS = ArgumentError(
+    "Encountered a control that needs losses but no losses found. ")
+
+const ERR_NEEDS_TRAINING_LOSSES = ArgumentError(
+    "Encountered a control that needs training losses but no training "*
+    "losses found. ")
 
 function train!(model, controls...; verbosity::Int=1)
 
     isempty(controls) && throw(ERR_TRAIN)
 
-    control = CompositeControl(controls...)
+    control = composite(controls...)
 
     # before training:
     verbosity > 1 && @info "Using these controls: $(flat(control)). "
@@ -15,6 +22,14 @@ function train!(model, controls...; verbosity::Int=1)
     state = update!(control, model, verbosity, n)
     finished = done(control, state)
 
+    # checks that model supports control:
+    if needs_loss(control) && loss(model) === nothing
+        throw(ERR_NEEDS_LOSS)
+    end
+    if needs_training_losses(control) && training_losses(model) === nothing
+        throw(ERR_NEEDS_TRAINING_LOSSES)
+    end
+
     # subsequent training events:
     while !finished
         n += 1
@@ -23,12 +38,12 @@ function train!(model, controls...; verbosity::Int=1)
     end
 
     # reporting final loss and training loss if available:
-    loss = IterationControl.loss(model)
-    training_losses = IterationControl.training_losses(model)
+    _loss = IterationControl.loss(model)
+    _training_losses = IterationControl.training_losses(model)
     if verbosity > 0
-        loss isa Nothing || @info "final loss: $loss"
-        training_losses isa Nothing || isempty(training_losses) ||
-            @info "final training loss: $(training_losses[end])"
+        _loss isa Nothing || @info "final loss: $_loss"
+        _training_losses isa Nothing || isempty(_training_losses) ||
+            @info "final training loss: $(_training_losses[end])"
         verbosity > 1 && @info "total control cycles: $n"
     end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,5 +1,6 @@
 model = Particle()
-invalid = InvalidValue()
+withloss = WithLossDo(x-> nothing)
+step = Step(1)
 
 @test_throws IC.ERR_TRAIN IterationControl.train!(model)
 @test_throws IC.err_train(model) IterationControl.train!(model, 1)
@@ -7,21 +8,21 @@ invalid = InvalidValue()
 # lifting train!:
 IC.train!(model::Particle, n) = train!(model, n)
 
-@test_throws(IC.err_getter(invalid, :loss, model),
-             IC.train!(model, invalid, NumberLimit(1)))
+@test_throws(IC.ERR_NEEDS_LOSS,
+             IC.train!(model, step, withloss, NumberLimit(1)))
 
 # lifting loss!:
 IterationControl.loss(m::Particle) = loss(m)
 
-IC.train!(model, invalid, NumberLimit(1), verbosity=0)
+@test_logs IC.train!(model, step, withloss, NumberLimit(1), verbosity=0)
 
-@test_throws(IC.err_getter(PQ(), :training_losses, model),
-             IC.train!(model, PQ(), NumberLimit(1)))
+@test_throws(IC.ERR_NEEDS_TRAINING_LOSSES,
+             IC.train!(model, step, PQ(), NumberLimit(1)))
 
 # lifting training_losses:
 IterationControl.training_losses(m::Particle) = training_losses(m)
 
-IC.train!(model, Step(2), PQ(), NumberLimit(1), verbosity=0)
+@test_logs IC.train!(model, Step(2), PQ(), NumberLimit(1), verbosity=0)
 
 @test_throws(IC.err_ingest(model),
              IC.train!(model, Data(1:2), NumberLimit(1)))
@@ -29,4 +30,4 @@ IC.train!(model, Step(2), PQ(), NumberLimit(1), verbosity=0)
 #lifting ingest!:
 IC.ingest!(model::Particle, datum) = ingest!(model, datum)
 
-IC.train!(model, Data(1:1), NumberLimit(1), verbosity=0);
+@test_logs IC.train!(model, Step(2), Data(1:1), NumberLimit(1), verbosity=0)

--- a/test/composite_controls.jl
+++ b/test/composite_controls.jl
@@ -47,7 +47,27 @@ end
     @test done_d == done_a || done_b || done_c
     report_d = IC.takedown(d, 0, state_d2)
     @test report_d == ((a, report_a), (b, report_b), (c, report_c))
+end
 
+@testset "traits" begin
+    needs_nothing = NumberLimit(4)
+    needs_loss = Threshold(0.01)
+    needs_training = WithTrainingLossesDo()
+    needs_both = PQ()
+
+    @test !IC.needs_loss(IC.composite(needs_nothing))
+    @test !IC.needs_loss(IC.composite(needs_nothing, needs_training))
+    @test IC.needs_loss(IC.composite(needs_nothing, needs_loss))
+    @test IC.needs_loss(IC.composite(needs_nothing, needs_both))
+    @test IC.needs_loss(IC.composite(needs_loss))
+    @test IC.needs_loss(IC.composite(needs_loss, needs_nothing))
+
+    @test !IC.needs_training_losses(IC.composite(needs_nothing))
+    @test IC.needs_training_losses(IC.composite(needs_nothing, needs_training))
+    @test !IC.needs_training_losses(IC.composite(needs_nothing, needs_loss))
+    @test IC.needs_training_losses(IC.composite(needs_nothing, needs_both))
+    @test IC.needs_training_losses(IC.composite(needs_training))
+    @test !IC.needs_training_losses(IC.composite(needs_loss, needs_nothing))
 end
 
 true

--- a/test/stopping_controls.jl
+++ b/test/stopping_controls.jl
@@ -1,20 +1,6 @@
-@testset "loss getters" begin
-    model=SquareRooter(4)
-    @test IterationControl.get_loss(InvalidValue(), model) ==
-        IterationControl.loss(model)
-    @test_throws(IterationControl.err_getter(InvalidValue(), :loss, :junk),
-                 IterationControl.get_loss(InvalidValue(), :junk))
-    IterationControl.train!(model, 2)
-    @test IterationControl.get_training_losses(PQ(), model) ==
-        IterationControl.training_losses(model)
-    @test_throws(
-        IterationControl.err_getter(PQ(), :training_losses, :junk),
-        IterationControl.get_training_losses(PQ(), :junk))
-end
-
 @testset "stopping criteria as controls" begin
 
-    # A stopping criterion than ignores training losses:
+    # A stopping criterion that ignores training losses:
 
     m = SquareRooter(4)
     c = NumberLimit(2)
@@ -56,5 +42,4 @@ end
     report = IC.takedown(c, 1, state)
     @test !report.done
     @test report.log == ""
-
 end

--- a/test/train.jl
+++ b/test/train.jl
@@ -109,3 +109,12 @@ end
             s.training_losses == reverse(tlosses[j-L+1:j])
     end |> all
 end
+
+# https://github.com/JuliaAI/MLJIteration.jl/issues/36
+@testset "integration test related to MLJIteration.jl #36" begin
+    model = SquareRooter(NaN)
+    report =
+        IC.train!(model, Step(1), InvalidValue(), NumberLimit(3), verbosity=0)
+    @test report[1][2].new_iterations == 1
+    @test occursin("Stopping", report[2][2].log)
+end


### PR DESCRIPTION
Needs EarlyStopping.jl version 0.3

- Adds the traits `needs_loss`, `needs_training_losses` that were
  removed from EarlyStopping in v0.3.0

- Changes the logic about how these are handled to correct previously
  unexpected behaviour discovered in MLJIteration.jl; see [this
  issue](JuliaAI/MLJIteration.jl#36). The
  traits have a slightly new interpretation: have `train!` throw an
  error if the trait is `true` for some control provided and the model
  has not been overloaded for `loss`/`training_losses`.

Resolves JuliaAI/MLJIteration.jl#36.